### PR TITLE
Amend LICENSE and remove CeCILL boilerplate

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,15 @@
+Copyright 2010-2016 Nicolas Debeissat and other contributors,
+http://debeissat.nicolas.free.fr/
+
+This software consists of voluntary contributions made by multiple individuals.
+For exact contribution history, see the revision history available at
+https://github.com/ndebeiss/jsXmlSaxParser
+
+The following license applies to all parts of this software except as documented
+below:
+
+--------------------------------------------------------------------------------
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -178,7 +190,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +198,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2010 Nicolas Debeissat
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,3 +211,16 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This software bundles a number of components and libraries with separate
+copyright notices and license terms, including the ones below. We recommend you
+read them, as their terms may differ from the terms above.
+
+JsUnit (http://www.jsunit.net/)
+  License: MPL 1.1, GPL 2.0, or LGPL 2.1 (See jsunit/licenses/index.html)
+
+XML W3C Conformance Test Suite (https://www.w3.org/XML/Test/)
+  License: See LICENSES FOR W3C TEST SUITES at
+  https://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html

--- a/tests/applyXslt.js
+++ b/tests/applyXslt.js
@@ -1,39 +1,4 @@
 /*global ActiveXObject, XSLTProcessor, window, xsltProcessor, createDocumentFromText, innerXML, XMLHttpRequest, alert, document, navigator */
-/*
-Copyright or © or Copr. Nicolas Debeissat
-
-nicolas.debeissat@gmail.com (http://debeissat.nicolas.free.fr/) brettz9@yahoo.com
-
-This software is a computer program whose purpose is to parse XML
-files respecting SAX2 specifications.
-
-This software is governed by the CeCILL license under French law and
-abiding by the rules of distribution of free software. You can use,
-modify and/ or redistribute the software under the terms of the CeCILL
-license as circulated by CEA, CNRS and INRIA at the following URL
-"http://www.cecill.info".
-
-As a counterpart to the access to the source code and rights to copy,
-modify and redistribute granted by the license, users are provided only
-with a limited warranty and the software's author, the holder of the
-economic rights, and the successive licensors have only limited
-liability.
-
-In this respect, the user's attention is drawn to the risks associated
-with loading, using, modifying and/or developing or reproducing the
-software by the user in light of its specific status of free software,
-that may mean that it is complicated to manipulate, and that also
-therefore means that it is reserved for developers and experienced
-professionals having in-depth computer knowledge. Users are therefore
-encouraged to load and test the software's suitability as regards their
-requirements in conditions enabling the security of their systems and/or
-data to be ensured and, more generally, to use and operate it in the
-same conditions as regards security.
-
-The fact that you are presently reading this means that you have had
-knowledge of the CeCILL license and that you accept its terms.
-
-*/
 
 function loadXMLDoc(fname) {
     var xmlDoc;

--- a/tests/dom_utils.js
+++ b/tests/dom_utils.js
@@ -1,39 +1,4 @@
 /*global ActiveXObject, DOMParser, XMLSerializer, XPathResult, window, document, is_ignorable*/
-/*
-Copyright or © or Copr. Nicolas Debeissat
-
-nicolas.debeissat@gmail.com (http://debeissat.nicolas.free.fr/) brettz9@yahoo.com
-
-This software is a computer program whose purpose is to parse XML
-files respecting SAX2 specifications.
-
-This software is governed by the CeCILL license under French law and
-abiding by the rules of distribution of free software. You can use,
-modify and/ or redistribute the software under the terms of the CeCILL
-license as circulated by CEA, CNRS and INRIA at the following URL
-"http://www.cecill.info".
-
-As a counterpart to the access to the source code and rights to copy,
-modify and redistribute granted by the license, users are provided only
-with a limited warranty and the software's author, the holder of the
-economic rights, and the successive licensors have only limited
-liability.
-
-In this respect, the user's attention is drawn to the risks associated
-with loading, using, modifying and/or developing or reproducing the
-software by the user in light of its specific status of free software,
-that may mean that it is complicated to manipulate, and that also
-therefore means that it is reserved for developers and experienced
-professionals having in-depth computer knowledge. Users are therefore
-encouraged to load and test the software's suitability as regards their
-requirements in conditions enabling the security of their systems and/or
-data to be ensured and, more generally, to use and operate it in the
-same conditions as regards security.
-
-The fact that you are presently reading this means that you have had
-knowledge of the CeCILL license and that you accept its terms.
-
-*/
 
 var ELEMENT_NODE = 1,
 ATTRIBUTE_NODE = 2,

--- a/tests/jsxmlunit.js
+++ b/tests/jsxmlunit.js
@@ -1,39 +1,4 @@
 /*global assertEquals, data_of, assertTrue, is_ignorable  */
-/*
-Copyright or © or Copr. Nicolas Debeissat, Brett Zamir
-
-nicolas.debeissat@gmail.com (http://debeissat.nicolas.free.fr/) brettz9@yahoo.com
-
-This software is a computer program whose purpose is to parse XML
-files respecting SAX2 specifications.
-
-This software is governed by the CeCILL license under French law and
-abiding by the rules of distribution of free software. You can use,
-modify and/ or redistribute the software under the terms of the CeCILL
-license as circulated by CEA, CNRS and INRIA at the following URL
-"http://www.cecill.info".
-
-As a counterpart to the access to the source code and rights to copy,
-modify and redistribute granted by the license, users are provided only
-with a limited warranty and the software's author, the holder of the
-economic rights, and the successive licensors have only limited
-liability.
-
-In this respect, the user's attention is drawn to the risks associated
-with loading, using, modifying and/or developing or reproducing the
-software by the user in light of its specific status of free software,
-that may mean that it is complicated to manipulate, and that also
-therefore means that it is reserved for developers and experienced
-professionals having in-depth computer knowledge. Users are therefore
-encouraged to load and test the software's suitability as regards their
-requirements in conditions enabling the security of their systems and/or
-data to be ensured and, more generally, to use and operate it in the
-same conditions as regards security.
-
-The fact that you are presently reading this means that you have had
-knowledge of the CeCILL license and that you accept its terms.
-
-*/
 
 /* comes from https://developer.mozilla.org/En/Code_snippets/LookupNamespaceURI */
 function lookupNamespaceURI (node, prefix) { // adapted directly from http://www.w3.org/TR/DOM-Level-3-Core/namespaces-algorithms.html#lookupNamespaceURIAlgo

--- a/tests/w3c_tests.js
+++ b/tests/w3c_tests.js
@@ -1,39 +1,4 @@
 /*global document, alert, assertTrue, DomContentHandler, JsUnitException , DefaultHandler2, SAXException, textContent, InputSource, Serializer, XMLReaderFactory, diffString, loadFile */
-/*
-Copyright or © or Copr. Nicolas Debeissat
-
-nicolas.debeissat@gmail.com (http://debeissat.nicolas.free.fr/) brettz9@yahoo.com
-
-This software is a computer program whose purpose is to parse XML
-files respecting SAX2 specifications.
-
-This software is governed by the CeCILL license under French law and
-abiding by the rules of distribution of free software. You can use,
-modify and/ or redistribute the software under the terms of the CeCILL
-license as circulated by CEA, CNRS and INRIA at the following URL
-"http://www.cecill.info".
-
-As a counterpart to the access to the source code and rights to copy,
-modify and redistribute granted by the license, users are provided only
-with a limited warranty and the software's author, the holder of the
-economic rights, and the successive licensors have only limited
-liability.
-
-In this respect, the user's attention is drawn to the risks associated
-with loading, using, modifying and/or developing or reproducing the
-software by the user in light of its specific status of free software,
-that may mean that it is complicated to manipulate, and that also
-therefore means that it is reserved for developers and experienced
-professionals having in-depth computer knowledge. Users are therefore
-encouraged to load and test the software's suitability as regards their
-requirements in conditions enabling the security of their systems and/or
-data to be ensured and, more generally, to use and operate it in the
-same conditions as regards security.
-
-The fact that you are presently reading this means that you have had
-knowledge of the CeCILL license and that you accept its terms.
-
-*/
 
 function throwNotFatalException(errorHandler) {
     if (errorHandler.saxParseExceptions.length > 0) {


### PR DESCRIPTION
Amends the LICENSE file with a jQuery Foundation-inspired header containing a blanket copyright notice that acknowledges multiple contributors and directs readers to the Github repository's revision history for an exact record of their contributions, and a footer containing a hopefully comprehensive listing of references to the copyright and license terms of all third-party components and libraries bundled with the project, along with a notice that they may differ from those of the Apache 2.0 license.

Removes all boilerplate CeCILL license notices to prevent the "strong copyleft" terms of CeCILL from potentially overriding the Apache 2.0 license. For reference, see, e.g., the "CeCILL is contaminating" bullet point under http://www.cecill.info/faq.en.html#utilisation-cecill; the "Compatibility of FOSS licenses" section at https://en.wikipedia.org/wiki/License_compatibility#Compatibility_of_FOSS_licenses; and the various reasons offered under "Which licenses may not be included within Apache products?" at http://apache.org/legal/resolved.html#category-x.
